### PR TITLE
Added alarmist-rollup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The following packages provide helpers and can be installed with npm.
 
 - [`alarmist-npm`](https://www.npmjs.com/package/alarmist-npm) - a simple wrapper for running npm scripts
 - [`alarmist-webpack`](https://www.npmjs.com/package/alarmist-webpack) - a wrapper for the webpack watcher to take advantage of fast incremental builds
+- [`alarmist-rollup`](https://github.com/jyboudreau/alarmist-rollup#readme) - a wrapper for the rollup watcher.
 
 ## Example `package.json` configuration
 


### PR DESCRIPTION
Thanks for Alarmist! I've used it quite a bit in my personal and work projects.

I thought I'd contribute by expanding the ecosystem a bit and add [alarmist-rollup](https://github.com/jyboudreau/alarmist-rollup) to the family.



